### PR TITLE
ml.Model -> ml.model 에러 제거.

### DIFF
--- a/6.CHATBOT/6.3 seq2seq/predict.py
+++ b/6.CHATBOT/6.3 seq2seq/predict.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
 
 	# 에스티메이터 구성
     classifier = tf.estimator.Estimator(
-            model_fn=ml.Model,
+            model_fn=ml.model,
             model_dir=DEFINES.check_point_path, 
             params={ 
                 'hidden_size': DEFINES.hidden_size, 


### PR DESCRIPTION
`ml.Model`함수를 사용시 아래와 같은 에러가 발생 `ml.model`로 변경시 에러가 발생하지 않고 정상 동작을 합니다.

```
Traceback (most recent call last):
  File "predict.py", line 30, in <module>
    model_fn=ml.Model,
AttributeError: module 'model' has no attribute 'Model'
```